### PR TITLE
Fix internal console hanging ComfyUI startup on non-Latin output (#38)

### DIFF
--- a/launcher.py
+++ b/launcher.py
@@ -276,6 +276,8 @@ def ensure_comfyui_running(comfy_path: str, port: int = 8188):
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             bufsize=1,
         )
 
@@ -359,11 +361,24 @@ def stop_comfyui_hard(comfy_path: str, _grace_period=5):
 
 
 def _read_process_output(proc: subprocess.Popen):
-    """Reads stdout of ComfyUI process and writes to ConsoleBuffer."""
+    """Drain the child's stdout into ConsoleBuffer.
+
+    This loop must never stop while the process is alive: if it dies, the OS
+    pipe buffer fills up, the child blocks on write, and ComfyUI hangs on
+    startup. Decoding is handled by Popen (utf-8, errors="replace"), so a
+    non-Latin byte from a custom node can no longer crash the reader; we still
+    guard each line so a single failure can't break the drain.
+    """
+    stdout = proc.stdout
+    if not stdout:
+        return
     try:
-        if proc.stdout:
-            for line in proc.stdout:
+        for line in stdout:
+            try:
                 ConsoleBuffer.add(line)
+            except Exception:
+                # Never let a buffering error stop us draining the pipe.
+                pass
     except Exception as e:
         ConsoleBuffer.add(f"[Console reader error] {e}\n")
 

--- a/tests/test_launcher_console.py
+++ b/tests/test_launcher_console.py
@@ -1,0 +1,62 @@
+"""Regression tests for the internal-console stdout reader (issue #38-B).
+
+Background: in internal-console mode the child was spawned with text=True but no
+explicit encoding, so the parent decoded stdout with the locale codec (cp1251 /
+charmap on RU Windows). A non-Latin byte from a custom node crashed the reader
+thread, which then stopped draining the pipe -> the child blocked on write ->
+ComfyUI hung on startup ("ComfyUI is not responding").
+"""
+
+import io
+
+from launcher import _read_process_output
+from utils.console_buffer import ConsoleBuffer
+
+
+class _FakeProc:
+    """Minimal stand-in for subprocess.Popen exposing only .stdout."""
+
+    def __init__(self, stdout):
+        self.stdout = stdout
+
+
+def setup_function(_):
+    ConsoleBuffer.clear()
+
+
+def test_reader_survives_undecodable_bytes():
+    # Exactly the failing scenario: a stray 0x98 (invalid UTF-8) between valid
+    # text, wrapped the same way Popen(encoding="utf-8", errors="replace") does.
+    raw = "Custom Node ".encode("utf-8") + b"\x98" + " loaded\n中文\n".encode("utf-8")
+    stream = io.TextIOWrapper(io.BytesIO(raw), encoding="utf-8", errors="replace")
+
+    _read_process_output(_FakeProc(stream))  # must not raise
+
+    out = ConsoleBuffer.get_all()
+    assert "Custom Node" in out
+    assert "loaded" in out
+    assert "中文" in out
+    assert "�" in out  # the bad byte became the replacement char
+    assert "[Console reader error]" not in out
+
+
+def test_reader_keeps_draining_after_buffer_error(monkeypatch):
+    # If ConsoleBuffer.add throws on one line, the loop must keep draining the
+    # rest — otherwise the pipe fills and the child blocks.
+    recorded = []
+
+    def flaky_add(cls, text):
+        if text == "b\n":
+            raise RuntimeError("boom")
+        recorded.append(text)
+
+    monkeypatch.setattr(ConsoleBuffer, "add", classmethod(flaky_add))
+
+    _read_process_output(_FakeProc(iter(["a\n", "b\n", "c\n"])))
+
+    assert recorded == ["a\n", "c\n"]
+
+
+def test_reader_handles_missing_stdout():
+    _read_process_output(_FakeProc(None))  # must not raise
+    assert ConsoleBuffer.get_all() == ""


### PR DESCRIPTION
In internal-console mode the child was spawned with text=True but no explicit encoding, so the parent decoded stdout with the locale codec (cp1251/charmap on RU Windows). A non-Latin byte from a custom node (e.g. 0x98) crashed the reader thread, which stopped draining the pipe; the child then blocked on write and ComfyUI hung on startup, surfacing as "ComfyUI is not responding".

- Spawn with encoding="utf-8", errors="replace" (matches the child's PYTHONIOENCODING=utf-8), so undecodable bytes become the replacement char instead of raising.
- Make _read_process_output resilient: guard each line so a single buffering error can never stop the loop draining the pipe.
- Add regression tests for the reader.