### PR TITLE
Allow non-portable / standalone ComfyUI builds (#37)

### DIFF
--- a/ui/dialogs/setup_window.py
+++ b/ui/dialogs/setup_window.py
@@ -380,13 +380,17 @@ class SetupWindow(QDialog):
             return
 
         if detect_build_type(path) == "standalone":
-            MB.warning(
+            proceed = MB.ask_yes_no(
                 self,
-                "Invalid build detected",
-                "This appears to be a standalone ComfyUI build or a third-party directory.\n"
-                "ComfyLauncher works only with the portable version.",
+                "Non-portable build",
+                "No embedded Python was found next to this folder, so it looks like "
+                "a non-portable or third-party ComfyUI install "
+                "(e.g. system Python or Stability Matrix).\n\n"
+                "ComfyLauncher will launch it using the system Python. "
+                "Add this build anyway?",
             )
-            return
+            if not proceed:
+                return
 
         if not name:
             MB.warning(self, "Missing name", "Please enter a build name.")


### PR DESCRIPTION
1.7.0 hard-blocked any folder without an embedded Python next to it (detect_build_type == "standalone" -> warning + return), so system-Python and Stability Matrix installs could no longer be added — a regression from 1.6.0. The launch path already falls back to the system "python" via resolve_python_exe, so the block was overly strict.

Replace the hard block with a yes/no confirmation: warn that it looks non-portable and will run under system Python, and proceed if the user agrees.