### PR TITLE
Store user config in %APPDATA% so all-users installs can save (#38-A)

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,5 +1,6 @@
 import json
 import os
+import shutil
 
 from utils.logger import log_event
 
@@ -90,7 +91,12 @@ OTHER_ICONS = {
     "comfyui": os.path.join(ICONS_DIR, "comfyui-text.svg"),
 }
 
-USER_CONFIG_PATH = os.path.join(BASE_DIR, "user_config.json")
+# ── User config ───────────────────────────────
+# Stored in %APPDATA% so it stays writable even for all-users installs
+# (Program Files, where the in-app folder is read-only). LEGACY_* is the old
+# in-app location, kept only for one-time migration of existing users.
+USER_CONFIG_PATH = os.path.join(APP_DATA_DIR, "user_config.json")
+LEGACY_USER_CONFIG_PATH = os.path.join(BASE_DIR, "user_config.json")
 
 # ── Launch presets ────────────────────────────
 LAUNCH_PRESETS = {
@@ -117,7 +123,27 @@ DEFAULT_USER_CONFIG = {
 }
 
 
+def _migrate_legacy_config():
+    """One-time move of a pre-%APPDATA% config from the in-app folder.
+
+    Only runs when no config exists at the new location yet, so it never
+    clobbers an existing one. Never raises.
+    """
+    if os.path.exists(USER_CONFIG_PATH):
+        return
+    if not os.path.exists(LEGACY_USER_CONFIG_PATH):
+        return
+    try:
+        os.makedirs(os.path.dirname(USER_CONFIG_PATH), exist_ok=True)
+        shutil.copy2(LEGACY_USER_CONFIG_PATH, USER_CONFIG_PATH)
+        log_event(f"🗂 Migrated user config to {USER_CONFIG_PATH}")
+    except Exception as e:
+        log_event(f"⚠️ Failed to migrate user config: {e}")
+
+
 def load_user_config():
+    _migrate_legacy_config()
+
     if not os.path.exists(USER_CONFIG_PATH):
         save_user_config(DEFAULT_USER_CONFIG)
         return DEFAULT_USER_CONFIG.copy()
@@ -144,13 +170,22 @@ def load_user_config():
         return DEFAULT_USER_CONFIG.copy()
 
 
-def save_user_config(data: dict):
+def save_user_config(data: dict) -> bool:
+    """Write the user config. Returns True on success, False on failure.
+
+    Never raises and never shows UI — it is also called from background threads
+    (e.g. the update checker). Callers on a UI path should check the return
+    value and warn the user if it is False.
+    """
     try:
+        os.makedirs(os.path.dirname(USER_CONFIG_PATH), exist_ok=True)
         with open(USER_CONFIG_PATH, "w", encoding="utf-8") as f:
             json.dump(data, f, indent=4, ensure_ascii=False)
+        return True
     except Exception as e:
         print(f"⚠️ Failed to save config: {e}")
         log_event(f"⚠️ Failed to save config: {e}")
+        return False
 
 
 def get_comfyui_path() -> str:

--- a/tests/test_config_migration.py
+++ b/tests/test_config_migration.py
@@ -1,0 +1,86 @@
+"""Tests for user-config location, migration and save error reporting (#38-A).
+
+The config moved from the in-app folder to %APPDATA% so it stays writable for
+all-users (Program Files) installs. save_user_config now returns a bool so the
+UI can surface failures instead of closing silently.
+"""
+
+import json
+
+import config
+
+
+def test_save_success_creates_dir_and_file(tmp_path, monkeypatch):
+    target = tmp_path / "appdata" / "user_config.json"
+    monkeypatch.setattr(config, "USER_CONFIG_PATH", str(target))
+
+    assert config.save_user_config({"a": 1}) is True
+    assert target.exists()
+    assert json.loads(target.read_text(encoding="utf-8")) == {"a": 1}
+
+
+def test_save_failure_returns_false(tmp_path, monkeypatch):
+    # Make the parent a real file so os.makedirs / open cannot succeed.
+    blocker = tmp_path / "afile"
+    blocker.write_text("x", encoding="utf-8")
+    target = blocker / "nope" / "user_config.json"
+    monkeypatch.setattr(config, "USER_CONFIG_PATH", str(target))
+
+    assert config.save_user_config({"a": 1}) is False
+
+
+def test_migration_copies_when_new_absent(tmp_path, monkeypatch):
+    legacy = tmp_path / "legacy" / "user_config.json"
+    legacy.parent.mkdir(parents=True)
+    legacy.write_text('{"builds": [{"id": "x"}]}', encoding="utf-8")
+    new = tmp_path / "appdata" / "user_config.json"
+
+    monkeypatch.setattr(config, "USER_CONFIG_PATH", str(new))
+    monkeypatch.setattr(config, "LEGACY_USER_CONFIG_PATH", str(legacy))
+
+    config._migrate_legacy_config()
+
+    assert new.exists()
+    assert json.loads(new.read_text(encoding="utf-8"))["builds"][0]["id"] == "x"
+
+
+def test_migration_does_not_clobber_existing(tmp_path, monkeypatch):
+    legacy = tmp_path / "legacy.json"
+    legacy.write_text('{"from": "legacy"}', encoding="utf-8")
+    new = tmp_path / "new.json"
+    new.write_text('{"from": "new"}', encoding="utf-8")
+
+    monkeypatch.setattr(config, "USER_CONFIG_PATH", str(new))
+    monkeypatch.setattr(config, "LEGACY_USER_CONFIG_PATH", str(legacy))
+
+    config._migrate_legacy_config()
+
+    assert json.loads(new.read_text(encoding="utf-8")) == {"from": "new"}
+
+
+def test_load_migrates_then_returns_builds(tmp_path, monkeypatch):
+    legacy = tmp_path / "legacy" / "user_config.json"
+    legacy.parent.mkdir(parents=True)
+    legacy.write_text('{"builds": [{"id": "keep-me"}]}', encoding="utf-8")
+    new = tmp_path / "appdata" / "user_config.json"
+
+    monkeypatch.setattr(config, "USER_CONFIG_PATH", str(new))
+    monkeypatch.setattr(config, "LEGACY_USER_CONFIG_PATH", str(legacy))
+
+    data = config.load_user_config()
+
+    assert new.exists()
+    assert data["builds"][0]["id"] == "keep-me"
+
+
+def test_load_creates_defaults_when_none(tmp_path, monkeypatch):
+    new = tmp_path / "appdata" / "user_config.json"
+    legacy = tmp_path / "legacy" / "user_config.json"  # absent
+
+    monkeypatch.setattr(config, "USER_CONFIG_PATH", str(new))
+    monkeypatch.setattr(config, "LEGACY_USER_CONFIG_PATH", str(legacy))
+
+    data = config.load_user_config()
+
+    assert new.exists()
+    assert "builds" in data

--- a/ui/dialogs/setup_window.py
+++ b/ui/dialogs/setup_window.py
@@ -432,7 +432,9 @@ class SetupWindow(QDialog):
             apply_manager_defaults(self.edit_build_id)
 
             data["builds"] = builds
-            save_user_config(data)
+            if not save_user_config(data):
+                self._warn_save_failed()
+                return
             self.accept()
             return
 
@@ -451,8 +453,18 @@ class SetupWindow(QDialog):
         data["builds"] = builds
         apply_manager_defaults(build_id)
 
-        save_user_config(data)
+        if not save_user_config(data):
+            self._warn_save_failed()
+            return
         self.accept()
+
+    def _warn_save_failed(self):
+        MB.warning(
+            self,
+            "Could not save",
+            "Failed to save the settings. Make sure the app can write to your "
+            "AppData folder, then try again.",
+        )
 
     def _on_doodle_selected(self):
         btn = self.sender()


### PR DESCRIPTION
The config lived next to the app (BASE_DIR/user_config.json). For an all-users install under Program Files that folder is read-only, so save_user_config failed silently and the setup window closed on OK without adding the build.

- Move USER_CONFIG_PATH to %APPDATA%/ComfyLauncher (always writable); keep LEGACY_USER_CONFIG_PATH and migrate an existing config once, without clobbering a new one.
- save_user_config now creates the target dir, returns bool, and never raises (it is called from background threads too).
- SetupWindow._accept checks the result and warns instead of closing silently on a save failure.
- Add config location/migration/save tests.

Note: the PyInstaller spec (gitignored) also drops the bundled user_config.json so releases no longer ship a dev config.