### PR TITLE
Drop always-on-top from splash so other windows can cover it

### DIFF
--- a/ui/splash_video.py
+++ b/ui/splash_video.py
@@ -22,9 +22,9 @@ class LauncherSplashVideo(QWidget):
         self.setWindowTitle("ComfyLauncher")
 
         # ─── Window flags ─────────────────────────────
-        self.setWindowFlags(
-            Qt.WindowType.FramelessWindowHint | Qt.WindowType.WindowStaysOnTopHint
-        )
+        # No WindowStaysOnTopHint: splash shows on top at creation (it gets focus),
+        # but other windows (opened folder / browser) can cover it afterwards.
+        self.setWindowFlags(Qt.WindowType.FramelessWindowHint)
 
         # ─── Layout ──────────────────────────────────
         layout = QVBoxLayout(self)


### PR DESCRIPTION
The splash used WindowStaysOnTopHint, so an opened folder or the browser stayed hidden behind it. Remove the flag: the splash still appears on top at creation (it receives focus) but can now be covered by other windows.