### PR TITLE
Translate two user-facing strings to English

### DIFF
--- a/ui/browser.py
+++ b/ui/browser.py
@@ -41,7 +41,7 @@ class StartingWidget(QWidget):
         layout = QVBoxLayout(self)
         layout.setAlignment(Qt.AlignmentFlag.AlignCenter)
 
-        label = QLabel("🚀 Запуск ComfyUI…")
+        label = QLabel("🚀 Starting ComfyUI…")
         label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         label.setStyleSheet("font-size: 18px; color: #cccccc;")
 

--- a/ui/webview2_widget.py
+++ b/ui/webview2_widget.py
@@ -68,9 +68,9 @@ class WebView2Widget(QWidget):
 
         if not (winforms_dll.exists() and core_dll.exists() and loader_dll.exists()):
             raise RuntimeError(
-                "Не найдены DLL WebView2 в папке:\n"
+                "WebView2 DLLs were not found in folder:\n"
                 f"{base}\n"
-                "Нужны: Microsoft.Web.WebView2.WinForms.dll, Microsoft.Web.WebView2.Core.dll, WebView2Loader.dll"
+                "Required: Microsoft.Web.WebView2.WinForms.dll, Microsoft.Web.WebView2.Core.dll, WebView2Loader.dll"
             )
 
         # важно: чтобы native loader точно находился


### PR DESCRIPTION
The loading label ("Запуск ComfyUI…") and the WebView2 missing-DLL error were the only Russian strings a user could actually see. Translate both to English for a consistent UI. Russian code comments are intentionally left for a separate cleanup.