### PR TITLE
Strip Mark-of-the-Web from bundled DLLs on startup (fixes ZIP launch …

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,6 +5,10 @@ os.environ["QT_MEDIA_BACKEND"] = "ffmpeg"
 os.environ["QT_FFMPEG_HWACCEL"] = "none"
 # os.environ["QSG_RHI_BACKEND"] = "software"
 
+# Must run before any CLR assembly load (pythonnet / WebView2 via ui.browser):
+# importing this module strips Mark-of-the-Web from bundled DLLs as a side effect.
+from utils import motw_unblock  # noqa: F401
+
 from PyQt6.QtWidgets import QApplication, QToolTip, QDialog
 from PyQt6.QtGui import QFont, QIcon
 from ui.browser import ComfyBrowser

--- a/utils/motw_unblock.py
+++ b/utils/motw_unblock.py
@@ -1,0 +1,41 @@
+"""Strip Mark-of-the-Web from bundled DLLs so .NET can load them.
+
+Importing this module performs the cleanup as a side effect. It MUST be
+imported before anything that triggers a CLR assembly load (pythonnet or
+WebView2) — i.e. before ``ui.browser``.
+
+Why: when the app is shipped as a ZIP, Windows Explorer tags every extracted
+file with a ``Zone.Identifier`` ("came from another computer") stream. .NET
+then refuses to load managed assemblies — pythonnet's ``Python.Runtime.dll``
+and WebView2's managed wrappers — and startup crashes with
+"Failed to resolve Python.Runtime.Loader.Initialize". Native ``LoadLibrary``
+is unaffected, so we only need the ``.dll`` streams gone before the first CLR
+assembly load. The installer build never hits this (it writes clean files),
+but the ZIP build does.
+"""
+
+import os
+import sys
+
+
+def unblock_bundled_dlls() -> None:
+    """Remove the Zone.Identifier stream from every bundled ``.dll``.
+
+    Runs only in a frozen build on Windows; a dev run has no MOTW. Best-effort:
+    any failure to remove a stream is ignored (missing stream, permissions).
+    """
+    if os.name != "nt":
+        return
+    base = getattr(sys, "_MEIPASS", None)
+    if not base:  # not frozen — nothing was extracted from a ZIP
+        return
+    for root, _dirs, files in os.walk(base):
+        for name in files:
+            if name.lower().endswith(".dll"):
+                try:
+                    os.remove(os.path.join(root, name) + ":Zone.Identifier")
+                except OSError:
+                    pass
+
+
+unblock_bundled_dlls()


### PR DESCRIPTION
…crash)

ZIP distributions crash on launch with "Failed to resolve Python.Runtime.Loader.Initialize": Windows Explorer tags every file extracted from an internet-downloaded ZIP with a Zone.Identifier stream, and .NET refuses to load managed assemblies (pythonnet's Python.Runtime.dll, WebView2's managed wrappers) that carry Mark-of-the-Web.

Add utils/motw_unblock.py, imported first in main.py (before ui.browser triggers the CLR), which removes the Zone.Identifier stream from every bundled .dll. Frozen-Windows only; a dev run and the installer build are no-ops. Best-effort — failures are ignored so it can never block startup.